### PR TITLE
Modified abs reference of pycryptodomex==3.11.0 to nearest compatible.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,8 @@ ARG BUILD_ARCH
 
 COPY requirements.txt ./
 RUN apk add --no-cache python3-dev py3-pip g++
-RUN pip install --upgrade pycryptodomex==3.11.0 --no-cache-dir -r requirements.txt
-
+RUN pip install --upgrade pycryptodomex~=3.11.0 --no-cache-dir -r requirements.txt
+# Modified cryptodomex to ~= from == GRL
 COPY SunGather/ /
 COPY SunGather/exports/ /exports
 COPY run.sh /


### PR DESCRIPTION
aiming to fix compatibility problem with the python crypto library install within the docker container.