### PR TITLE
Update Dockerfile to fix install error 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ ARG BUILD_ARCH
 
 COPY requirements.txt ./
 RUN apk add --no-cache python3-dev py3-pip g++
-RUN pip install --upgrade pycryptodomex==3.11.0 --no-cache-dir -r requirements.txt
+RUN pip install --break-system-packages --upgrade pycryptodomex==3.11.0 --no-cache-dir -r requirements.txt
 
 COPY SunGather/ /
 COPY SunGather/exports/ /exports

--- a/ModbusTCP.py
+++ b/ModbusTCP.py
@@ -140,7 +140,7 @@ client.close()
 logging.info("Modbus connected")
 
 # Configure MQTT
-mqtt_client = mqtt.Client("ModbusTCP")
+mqtt_client = mqtt.Client(mqtt.CallbackAPIVersion.VERSION1, "ModbusTCP")
 mqtt_client.username_pw_set(options['mqtt_user'], options['mqtt_pass'])
 if options['mqtt_port'] == 8883:
     mqtt_client.tls_set()


### PR DESCRIPTION
Added `--break-system-packages` to pip install pycryptodomex line in docker file which fixes #73 and #74. This should not have any issues with the system as the change is local to the docker container.

Note that I need someone to test on a known working system/config. I'm still working through another issue with having the add on connect to MQTT which may or may not be related to this library.